### PR TITLE
Require fix for XRegExp 3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "methods": "^1.1.1",
     "path-to-regexp": "^1.2.1",
-    "xregexp": "~3.1.0"
+    "xregexp": "^3.1.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "dependencies": {
     "methods": "^1.1.1",
     "path-to-regexp": "^1.2.1",
-    "xregexp": "^3.0.0"
+    "xregexp": "~3.1.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/route.js
+++ b/route.js
@@ -1,4 +1,4 @@
-var XRegExp = require('xregexp').XRegExp;
+var XRegExp = require('xregexp');
 
 exports = module.exports = Route;
 


### PR DESCRIPTION
XRegExp published version 3.1.0 which no longer exports XRegExp.XRegExp.
See this commit: https://github.com/slevithan/xregexp/commit/a82af2cc9f545449c009961e79e9ed47bcfc2e92