### PR TITLE
use an object instead of an array

### DIFF
--- a/router.js
+++ b/router.js
@@ -14,7 +14,7 @@ function Router(options) {
 
   this.expressMode = false;
 
-  this.routesByMethod = [];
+  this.routesByMethod = {};
   this.routesByMethodAndPath = {};
   this.routesByNameAndMethod = {};
   this.callbacksByPathAndMethod = {};


### PR DESCRIPTION
For me it looks like that it makes more sense to an object instead of an array.

If an array is used the following statement would try to get the property `get` of the Array-Object:

```
var method = 'get';
this.routesByMethod[method] = this.routesByMethod[method] || [];
```

and not the `get` property of my custom object.